### PR TITLE
Add Dependency Injection and Movie Model with API Integration

### DIFF
--- a/lib/core/di/dependency_injection.dart
+++ b/lib/core/di/dependency_injection.dart
@@ -1,0 +1,16 @@
+import 'package:dio/dio.dart';
+import 'package:get_it/get_it.dart';
+
+import '../networking/api_constants.dart';
+import '../networking/api_service.dart';
+import '../networking/dio_factory.dart';
+
+final GetIt getIt = GetIt.instance;
+Future<void> setupGetIt() async {
+  getIt.registerSingleton<GetIt>(getIt);
+  Dio dio = DioFactory.getDio();
+  getIt.registerLazySingleton<ApiService>(() => ApiService(
+        dio,
+        baseUrl: ApiConstants.apiBaseUrl,
+      ));
+}

--- a/lib/core/models/movie.dart
+++ b/lib/core/models/movie.dart
@@ -1,0 +1,37 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'movie.g.dart';
+@JsonSerializable()
+class Movie {
+  bool? adult;
+  String? backdropPath;
+  List<int>? genreIds;
+  int? id;
+  String? originalLanguage;
+  String? originalTitle;
+  String? overview;
+  double? popularity;
+  String? posterPath;
+  String? releaseDate;
+  String? title;
+  bool? video;
+  double? voteAverage;
+  int? voteCount;
+  Movie(this.adult,
+      this.backdropPath,
+      this.genreIds,
+      this.id,
+      this.originalLanguage,
+      this.originalTitle,
+      this.overview,
+      this.popularity,
+      this.posterPath,
+      this.releaseDate,
+      this.title,
+      this.video,
+      this.voteAverage,
+      this.voteCount);
+
+  factory Movie.fromJson(Map<String, dynamic> json) => _$MovieFromJson(json);
+  Map<String, dynamic> toJson() => _$MovieToJson(this);
+}

--- a/lib/core/models/movie.g.dart
+++ b/lib/core/models/movie.g.dart
@@ -1,0 +1,43 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'movie.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Movie _$MovieFromJson(Map<String, dynamic> json) => Movie(
+      json['adult'] as bool?,
+      json['backdropPath'] as String?,
+      (json['genreIds'] as List<dynamic>?)
+          ?.map((e) => (e as num).toInt())
+          .toList(),
+      (json['id'] as num?)?.toInt(),
+      json['originalLanguage'] as String?,
+      json['originalTitle'] as String?,
+      json['overview'] as String?,
+      (json['popularity'] as num?)?.toDouble(),
+      json['posterPath'] as String?,
+      json['releaseDate'] as String?,
+      json['title'] as String?,
+      json['video'] as bool?,
+      (json['voteAverage'] as num?)?.toDouble(),
+      (json['voteCount'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$MovieToJson(Movie instance) => <String, dynamic>{
+      'adult': instance.adult,
+      'backdropPath': instance.backdropPath,
+      'genreIds': instance.genreIds,
+      'id': instance.id,
+      'originalLanguage': instance.originalLanguage,
+      'originalTitle': instance.originalTitle,
+      'overview': instance.overview,
+      'popularity': instance.popularity,
+      'posterPath': instance.posterPath,
+      'releaseDate': instance.releaseDate,
+      'title': instance.title,
+      'video': instance.video,
+      'voteAverage': instance.voteAverage,
+      'voteCount': instance.voteCount,
+    };

--- a/lib/core/networking/api_constants.dart
+++ b/lib/core/networking/api_constants.dart
@@ -1,7 +1,7 @@
 class ApiConstants {
   static const String apiBaseUrl = "https://api.themoviedb.org/";
-  static const String apiKey =
-      "7f230be4c543fc126cc884925efe8032";
+  static const String authorization =
+      "Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiI3ZjIzMGJlNGM1NDNmYzEyNmNjODg0OTI1ZWZlODAzMiIsIm5iZiI6MTcyNDU0MDkxOC4xODg2MDQsInN1YiI6IjY2Y2E2NWUyYmI0Yzk2YTdjZjBkMmQxZSIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.oomLrpTIelNZC1RO9XN7HWoZGQ_0adrUVYxqPcLaya4";
   static const popular = '3/movie/popular';
 }
 

--- a/lib/core/networking/api_service.dart
+++ b/lib/core/networking/api_service.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 
@@ -8,8 +6,9 @@ import 'api_constants.dart';
 part 'api_service.g.dart';
 
 @RestApi(baseUrl: ApiConstants.apiBaseUrl)
-// @Headers( "en")
 abstract class ApiService {
   factory ApiService(Dio dio, {String baseUrl}) = _ApiService;
-
+  @GET(ApiConstants.popular)
+  Future<dynamic> getPopularMovies(
+      @Header('Authorization') String authorization);
 }

--- a/lib/core/networking/api_service.g.dart
+++ b/lib/core/networking/api_service.g.dart
@@ -23,6 +23,34 @@ class _ApiService implements ApiService {
 
   final ParseErrorLogger? errorLogger;
 
+  @override
+  Future<dynamic> getPopularMovies(String authorization) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{r'Authorization': authorization};
+    _headers.removeWhere((k, v) => v == null);
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<dynamic>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+        .compose(
+          _dio.options,
+          '3/movie/popular',
+          queryParameters: queryParameters,
+          data: _data,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
+    final _result = await _dio.fetch(_options);
+    final _value = _result.data;
+    return _value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/features/home/data/repo/movie_response_body.dart
+++ b/lib/features/home/data/repo/movie_response_body.dart
@@ -1,0 +1,17 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import '../../../../core/models/movie.dart';
+
+part 'movie_response_body.g.dart';
+@JsonSerializable()
+class MovieResponseBody {
+  final int page ; 
+  final List<Movie> results;
+  final int totalPages;
+  final int totalResults;
+  MovieResponseBody( this.page, this.results, this.totalPages, this.totalResults);
+
+
+  factory MovieResponseBody.fromJson(Map<String, dynamic> json) => _$MovieResponseBodyFromJson(json);
+  Map<String, dynamic> toJson() => _$MovieResponseBodyToJson(this);
+}

--- a/lib/features/home/data/repo/movie_response_body.g.dart
+++ b/lib/features/home/data/repo/movie_response_body.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'movie_response_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MovieResponseBody _$MovieResponseBodyFromJson(Map<String, dynamic> json) =>
+    MovieResponseBody(
+      (json['page'] as num).toInt(),
+      (json['results'] as List<dynamic>)
+          .map((e) => Movie.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      (json['totalPages'] as num).toInt(),
+      (json['totalResults'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$MovieResponseBodyToJson(MovieResponseBody instance) =>
+    <String, dynamic>{
+      'page': instance.page,
+      'results': instance.results,
+      'totalPages': instance.totalPages,
+      'totalResults': instance.totalResults,
+    };


### PR DESCRIPTION
- Introduced a new file `dependency_injection.dart` in `lib/core/di/` to set up dependency injection using `GetIt`. This includes registering a singleton instance of `GetIt`, creating a `Dio` instance via `DioFactory`, and registering an `ApiService` lazily with the base URL from `ApiConstants`.
- Created a `Movie` model in `lib/core/models/movie.dart` with JSON serialization capabilities, including fields for movie details such as title, release date, and vote average.
- Updated `api_constants.dart` to include an authorization token for API requests instead of an API key.
- Enhanced `api_service.dart` to include a method for fetching popular movies using the new authorization token.
- Generated the necessary part files (`movie.g.dart` and `api_service.g.dart`) for JSON serialization and Retrofit API service.
- Added a `MovieResponseBody` model in `lib/features/home/data/repo/` to handle the response structure from the movie API, including pagination details and a list of `Movie` objects.
- Generated the corresponding part file `movie_response_body.g.dart` for JSON serialization of `MovieResponseBody`.

This commit sets up the foundational structure for fetching and displaying movie data in the application, leveraging dependency injection for modularity and maintainability.