### PR TITLE
Refactor NewReleaseWidget to handle pagination state updates

### DIFF
--- a/lib/features/home/view/widget/new_release_widget.dart
+++ b/lib/features/home/view/widget/new_release_widget.dart
@@ -41,6 +41,9 @@ class _NewReleaseWidgetState extends State<NewReleaseWidget> {
         !(context.read<ReleasesCubit>().state is LoadingReleases)) {
       // If the user has reached the end of the list, fetch the next page
       context.read<ReleasesCubit>().getReleases(isPagination: true);
+      setState(() {
+        
+      });
     }
   }
 


### PR DESCRIPTION
Previously, the `NewReleaseWidget` did not properly update its state when fetching new releases for pagination. This commit introduces a call to `setState` within the pagination logic to ensure the widget rebuilds and reflects the loading state correctly. This change enhances the user experience by providing visual feedback during pagination operations.